### PR TITLE
Adding Nomad Allocation ID Property & OTel Work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add GitHub Action to push package to PyPi
 
+## [0.3.0] - 2023-01-13
+
+### Added
+
+- A little context awareness when working with services running in Nomad.
+  - Example, `ServiceHealth` now has the `alloc_id` property
+
+### Changed
+
+- Limiting usage of imports from `typing`
+  - For example, moving more hinting of lists from `List` to `list`
+
+### Internal
+
+- Added `Makefile` to make a few things easier to call all the time.
+
 ## [0.2.0] - 2022-10-27
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+lint:
+	poetry run pylint hc_pyconsul/
+	poetry run flake8 .
+	poetry run mypy hc_pyconsul/
+
+test: tests
+	poetry run pytest --cov=hc_pyconsul tests/ --junitxml=report.xml --cov-report xml:coverage.xml
+
+pre-commit:
+	make lint
+	make test
+
+dev: pyproject.toml
+	poetry install --no-root --no-interaction
+
+lint-ci:
+	make dev
+	make lint
+
+test-ci:
+	make dev
+	make test
+
+dev-pip:
+	pip install . && pip install ".[testing]"

--- a/hc_pyconsul/helpers/services.py
+++ b/hc_pyconsul/helpers/services.py
@@ -1,0 +1,37 @@
+import re
+
+from hc_pyconsul.models.helpers import NomadAllocation
+
+
+def extract_alloc_id_from_service_name(service_id: str) -> NomadAllocation:
+    """
+    Extracts the Nomad allocation ID from a Consul service name.
+
+    Parameters
+    ----------
+    service_id: str
+
+    Returns
+    -------
+    alloc_id: NomadAllocation
+
+    Raises
+    ------
+    FailedExtractingAllocID
+    """
+
+    alloc_id = NomadAllocation()
+
+    full_id = re.match(r'^_nomad-task-(\w+-\w+-\w+-\w+-\w+)', service_id)
+
+    if not full_id:
+        return alloc_id
+
+    try:
+        full_id_groups = full_id.groups()[0].split('-')
+        alloc_id = NomadAllocation(id=full_id_groups[0], id_long='-'.join(full_id_groups))
+    except AttributeError:
+        # Gracefully exit and allow default values of empty strings be provided.
+        pass
+
+    return alloc_id

--- a/hc_pyconsul/lib/catalog.py
+++ b/hc_pyconsul/lib/catalog.py
@@ -1,6 +1,3 @@
-from typing import Dict
-from typing import List
-
 from pydantic.dataclasses import dataclass
 
 from hc_pyconsul.lib.consul import ConsulAPI
@@ -9,10 +6,11 @@ from hc_pyconsul.lib.tracing import tracing
 
 @dataclass
 class ConsulCatalog(ConsulAPI):
+    endpoint = 'catalog'
 
     # pylint: disable=invalid-name
     @tracing('List Services')
-    def list_services(self, dc: str = None, node_meta: List[str] = None, namespace: str = None) -> Dict[str, List[str]]:
+    def list_services(self, dc: str = None, node_meta: list[str] = None, namespace: str = None) -> dict[str, list[str]]:
         """
         Link to official docs:
             https://developer.hashicorp.com/consul/api-docs/catalog#list-services
@@ -22,7 +20,7 @@ class ConsulCatalog(ConsulAPI):
         dc: str = None
             Specifies the datacenter to query.
             This will default to the datacenter of the agent being queried.
-        node_meta: List[str] = None
+        node_meta: list[str] = None
             Specifies a desired node metadata key/value in the form of key:value.
             This parameter can be specified multiple times,
             and filters the results to nodes with the specified key/value pairs.
@@ -32,7 +30,8 @@ class ConsulCatalog(ConsulAPI):
 
         Returns
         -------
-        services: Dict[str, List[str]]
+        services: dict[str, list[str]]
+            The list[str] is the tags for the given service.
 
         """
         params = {}
@@ -51,6 +50,6 @@ class ConsulCatalog(ConsulAPI):
                 'ns': namespace
             })
 
-        results = self.call_api(endpoint='/catalog/services', verb='GET', params=params)
+        results = self.call_api(endpoint=f'/{self.endpoint}/services', verb='GET', params=params)
 
         return results

--- a/hc_pyconsul/lib/tracing.py
+++ b/hc_pyconsul/lib/tracing.py
@@ -7,18 +7,11 @@ tracer = trace.get_tracer(__name__)
 
 def tracing(name):
     """Used to instrument pieces of the library with OpenTelemetry"""
+
     def outter_wrap(func):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
-            context = kwargs.get('context', None)
-            with tracer.start_as_current_span(name=f'Consul - {name}', context=context, kind=trace.SpanKind.CLIENT) as span:
-
-                # Remove context from the kwargs as the receiving
-                # method won't be looking for it.
-                try:
-                    del kwargs['context']
-                except KeyError:
-                    pass
+            with tracer.start_as_current_span(name=f'Consul - {name}', kind=trace.SpanKind.CLIENT) as span:
 
                 try:
                     results = func(self, *args, **kwargs)

--- a/hc_pyconsul/models/health.py
+++ b/hc_pyconsul/models/health.py
@@ -1,6 +1,9 @@
 from pydantic import BaseModel
 from pydantic import Field
 
+from hc_pyconsul.helpers.services import extract_alloc_id_from_service_name
+from hc_pyconsul.models.helpers import NomadAllocation
+
 
 class HealthCheck(BaseModel):
     node: str = Field(..., alias='Node')
@@ -60,3 +63,9 @@ class ServiceHealth(BaseModel):
     node: ServiceNode = Field(..., alias='Node')
     service: Service = Field(..., alias='Service')
     checks: list[HealthCheck] = Field(default_factory=list, alias='Checks')
+
+    @property
+    def alloc_id(self) -> NomadAllocation:
+        """Attempts to extract out the Nomad allocation ID for the given service check."""
+
+        return extract_alloc_id_from_service_name(service_id=self.service.id)

--- a/hc_pyconsul/models/helpers.py
+++ b/hc_pyconsul/models/helpers.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import Field
+
+
+class NomadAllocation(BaseModel):
+    id: Optional[str] = Field(default_factory=str)
+    id_long: Optional[str] = Field(default_factory=str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hc_pyconsul"
-version = "0.2.0"
+version = "0.3.0"
 description = "API client for HashiCorp Consul"
 authors = ["Arden Shackelford <arden@ardens.tech>"]
 license = "Apache 2.0"
@@ -11,21 +11,21 @@ packages = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.8.1,<4.0"
 httpx = "^0.23.0"
 pydantic = "^1.9.0"
 opentelemetry-api = "^1.13.0"
 
 [tool.poetry.group.testing.dependencies]
 pytest-cov = "^3.0.0"
-pylint = "^2.15.0"
-flake8 = "^4.0.1"
+pylint = "^2.16.1"
+flake8 = "^6.0.0"
 mypy = "^0.950"
-respx = "^0.19.2"
-pytest = "^7.1.3"
+respx = "^0.20.1"
+pytest = "^7.2.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.4.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pylint.'MESSAGES CONTROL']

--- a/tests/fixtures/health/responses.py
+++ b/tests/fixtures/health/responses.py
@@ -1,68 +1,137 @@
 HEALTH_SERVICES_LIST = [
-  {
-    "Node": {
-      "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
-      "Node": "foobar",
-      "Address": "10.1.10.12",
-      "Datacenter": "dc1",
-      "TaggedAddresses": {
-        "lan": "10.1.10.12",
-        "wan": "10.1.10.12"
-      },
-      "Meta": {
-        "instance_type": "t2.medium"
-      }
-    },
-    "Service": {
-      "ID": "redis",
-      "Service": "redis",
-      "Tags": ["primary"],
-      "Address": "10.1.10.12",
-      "TaggedAddresses": {
-        "lan": {
-          "address": "10.1.10.12",
-          "port": 8000
+    {
+        "Node": {
+            "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
+            "Node": "foobar",
+            "Address": "10.1.10.12",
+            "Datacenter": "dc1",
+            "TaggedAddresses": {
+                "lan": "10.1.10.12",
+                "wan": "10.1.10.12"
+            },
+            "Meta": {
+                "instance_type": "t2.medium"
+            }
         },
-        "wan": {
-          "address": "198.18.1.2",
-          "port": 80
-        }
-      },
-      "Meta": {
-        "redis_version": "4.0"
-      },
-      "Port": 8000,
-      "Weights": {
-        "Passing": 10,
-        "Warning": 1
-      },
-      "Namespace": "default"
-    },
-    "Checks": [
-      {
-        "Node": "foobar",
-        "CheckID": "service:redis",
-        "Name": "Service 'redis' check",
-        "Status": "passing",
-        "Notes": "",
-        "Output": "",
-        "ServiceID": "redis",
-        "ServiceName": "redis",
-        "ServiceTags": ["primary"],
-        "Namespace": "default"
-      },
-      {
-        "Node": "foobar",
-        "CheckID": "serfHealth",
-        "Name": "Serf Health Status",
-        "Status": "passing",
-        "Notes": "",
-        "Output": "",
-        "ServiceID": "",
-        "ServiceName": "",
-        "ServiceTags": [],
-        "Namespace": "default"
-      }
-    ]
-  }
+        "Service": {
+            "ID": "redis",
+            "Service": "redis",
+            "Tags": ["primary"],
+            "Address": "10.1.10.12",
+            "TaggedAddresses": {
+                "lan": {
+                    "address": "10.1.10.12",
+                    "port": 8000
+                },
+                "wan": {
+                    "address": "198.18.1.2",
+                    "port": 80
+                }
+            },
+            "Meta": {
+                "redis_version": "4.0"
+            },
+            "Port": 8000,
+            "Weights": {
+                "Passing": 10,
+                "Warning": 1
+            },
+            "Namespace": "default"
+        },
+        "Checks": [
+            {
+                "Node": "foobar",
+                "CheckID": "service:redis",
+                "Name": "Service 'redis' check",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "redis",
+                "ServiceName": "redis",
+                "ServiceTags": ["primary"],
+                "Namespace": "default"
+            },
+            {
+                "Node": "foobar",
+                "CheckID": "serfHealth",
+                "Name": "Serf Health Status",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "",
+                "ServiceName": "",
+                "ServiceTags": [],
+                "Namespace": "default"
+            }
+        ]
+    }
+]
+
+SERVICE_LIST_NOMAD = [
+    {
+        "Node": {
+            "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
+            "Node": "foobar",
+            "Address": "10.1.10.12",
+            "Datacenter": "dc1",
+            "TaggedAddresses": {
+                "lan": "10.1.10.12",
+                "wan": "10.1.10.12"
+            },
+            "Meta": {
+                "instance_type": "t2.medium"
+            }
+        },
+        "Service": {
+            "ID": '_nomad-task-86c6736f-33d2-e3b1-69a2-8189031eb599-service-01',
+            "Service": "redis",
+            "Tags": ["primary"],
+            "Address": "10.1.10.12",
+            "TaggedAddresses": {
+                "lan": {
+                    "address": "10.1.10.12",
+                    "port": 8000
+                },
+                "wan": {
+                    "address": "198.18.1.2",
+                    "port": 80
+                }
+            },
+            "Meta": {
+                "redis_version": "4.0"
+            },
+            "Port": 8000,
+            "Weights": {
+                "Passing": 10,
+                "Warning": 1
+            },
+            "Namespace": "default"
+        },
+        "Checks": [
+            {
+                "Node": "foobar",
+                "CheckID": "service:redis",
+                "Name": "Service 'redis' check",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "redis",
+                "ServiceName": "redis",
+                "ServiceTags": ["primary"],
+                "Namespace": "default"
+            },
+            {
+                "Node": "foobar",
+                "CheckID": "serfHealth",
+                "Name": "Serf Health Status",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "",
+                "ServiceName": "",
+                "ServiceTags": [],
+                "Namespace": "default"
+            }
+        ]
+    }
 ]

--- a/tests/test_helpers_services.py
+++ b/tests/test_helpers_services.py
@@ -1,0 +1,21 @@
+import unittest
+
+from hc_pyconsul.helpers.services import extract_alloc_id_from_service_name
+
+
+class TestHelpersExtractAllocationID(unittest.TestCase):
+    def test_extract_alloc_id(self):
+        results = extract_alloc_id_from_service_name(
+            service_id='_nomad-task-86c6736f-33d2-e3b1-69a2-8189031eb599-service-01'
+        )
+
+        assert results.id == '86c6736f'
+        assert results.id_long == '86c6736f-33d2-e3b1-69a2-8189031eb599'
+
+    def test_extract_alloc_id_unknown_pattern(self):
+        results = extract_alloc_id_from_service_name(
+            service_id='86c6736f-33d2-e3b1-69a2-8189031eb599'
+        )
+
+        assert results.id == ''
+        assert results.id_long == ''

--- a/tests/test_lib_consul_catalog.py
+++ b/tests/test_lib_consul_catalog.py
@@ -22,7 +22,7 @@ class TestListServices(TestCase):
             "postgresql": ["primary", "secondary"]
         }
 
-        response = respx.get('http://localhost:8500/v1/catalog/services')
+        response = respx.get(url='http://localhost:8500/v1/catalog/services')
         response.return_value = Response(200, json=call_response)
 
         services = self.test_catalog.list_services()

--- a/tests/test_lib_consul_health.py
+++ b/tests/test_lib_consul_health.py
@@ -37,4 +37,14 @@ class TestListServiceInstances(TestCase):
 
         services: list[ServiceHealth] = self.test_health.list_service_instances(service='foobar')
 
-        self.assertEqual(services[0].service.id, 'redis')
+        self.assertEqual('redis', services[0].service.id)
+
+    @respx.mock
+    def test_valid_response_with_nomad_service(self):
+        response = respx.get('http://localhost:8500/v1/health/service/foobar')
+        response.return_value = Response(200, json=responses.SERVICE_LIST_NOMAD)
+
+        services: list[ServiceHealth] = self.test_health.list_service_instances(service='foobar')
+
+        self.assertEqual('86c6736f', services[0].alloc_id.id)
+        self.assertEqual('86c6736f-33d2-e3b1-69a2-8189031eb599', services[0].alloc_id.id_long)


### PR DESCRIPTION
## [0.3.0] - 2023-01-13

### Added

- A little context awareness when working with services running in Nomad.
  - Example, `ServiceHealth` now has the `alloc_id` property

### Changed

- Limiting usage of imports from `typing`
  - For example, moving more hinting of lists from `List` to `list`

### Internal

- Added `Makefile` to make a few things easier to call all the time.